### PR TITLE
feat(tmux): 2-line status bar with session + window tabs

### DIFF
--- a/tmux/switch-session-click.sh
+++ b/tmux/switch-session-click.sh
@@ -1,15 +1,28 @@
 #!/bin/sh
-# Switch to the session under the mouse cursor based on X position.
-# Each session is rendered as " name " (space-padded) in the status bar.
-# #{S:} iterates in creation order, so we must match that here.
+# Click handler for the 2-line status bar.
+# Line 0: switch session, Line 1: switch window.
 mouse_x=$1
-pos=0
-tmux list-sessions -F '#{session_created} #{session_name}' | sort -n | awk '{print $2}' | while read -r name; do
-  # Each tab is " name " = len(name) + 2
-  width=$((${#name} + 2))
-  if [ "$mouse_x" -ge "$pos" ] && [ "$mouse_x" -lt "$((pos + width))" ]; then
-    tmux switch-client -t "$name"
-    exit 0
-  fi
-  pos=$((pos + width))
-done
+mouse_y=${2:-0}
+
+if [ "$mouse_y" = "0" ]; then
+  pos=0
+  tmux list-sessions -F '#{session_name}' | sort | while read -r name; do
+    width=$((${#name} + 2))
+    if [ "$mouse_x" -ge "$pos" ] && [ "$mouse_x" -lt "$((pos + width))" ]; then
+      tmux switch-client -t "$name"
+      exit 0
+    fi
+    pos=$((pos + width))
+  done
+elif [ "$mouse_y" = "1" ]; then
+  pos=0
+  tmux list-windows -F '#{window_index}:#{window_name}' | while read -r entry; do
+    width=$((${#entry} + 2))
+    if [ "$mouse_x" -ge "$pos" ] && [ "$mouse_x" -lt "$((pos + width))" ]; then
+      index="${entry%%:*}"
+      tmux select-window -t ":$index"
+      exit 0
+    fi
+    pos=$((pos + width))
+  done
+fi

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -37,25 +37,18 @@ setw -g pane-base-index 0
 set -g allow-rename off # After renaming the window, don't automatically rename it again
 set -g renumber-windows on # Renumber windows when a window is closed
 
-set -g status on
+set -g status 2
 set -g status-position top
 set -g status-style 'bg=#3b3b50,fg=white'
-set -g status-left ''
-set -g status-right ''
-set -g status-justify left
 
-# Show all sessions as tabs in the status bar
-set -g status-left-length 200
-set -g status-left '#{S:#{?#{==:#{session_name},#{client_session}},#[bg=#7aa2f7#,fg=#1a1a2e#,bold] #{session_name} #[bg=#3b3b50],#[bg=#3b3b50#,fg=#888899] #{session_name} #[default]}}'
-set -g status-right-length 0
+# Line 0: clickable session tabs
+set -g status-format[0] '#{S:#{?#{==:#{session_name},#{client_session}},#[bg=#7aa2f7#,fg=#1a1a2e#,bold] #{session_name} #[bg=#3b3b50],#[bg=#3b3b50#,fg=#888899] #{session_name} #[default]}}'
 
-# Click status bar to switch to session under cursor
-bind -n MouseUp1StatusLeft run-shell '~/.config/tmux/switch-session-click.sh #{mouse_x}'
-bind -n MouseUp1Status run-shell '~/.config/tmux/switch-session-click.sh #{mouse_x}'
+# Line 1: clickable window tabs for active session
+set -g status-format[1] '#{W:#{?#{window_active},#[bg=#7aa2f7#,fg=#1a1a2e#,bold] #{window_index}:#{window_name} #[bg=#3b3b50],#[bg=#3b3b50#,fg=#888899] #{window_index}:#{window_name} #[default]}}'
 
-# Hide the window list (we're using sessions as tabs)
-setw -g window-status-format ''
-setw -g window-status-current-format ''
+# Click status bar to switch session (line 0) or window (line 1)
+bind -n MouseUp1StatusDefault run-shell '~/.config/tmux/switch-session-click.sh #{mouse_x} #{mouse_y}'
 
 # Closing a session/window/whatever doesn't exit out of tmux, but moves to another session.
 set -g detach-on-destroy off


### PR DESCRIPTION
Match the macOS branch's tmux behaviour: top bar now shows both the session name (line 0) and the active session's window names (line 1), instead of session-only.